### PR TITLE
[codex] Allow Cast provider manifest replacement

### DIFF
--- a/.github/scripts/verify-packed-example.sh
+++ b/.github/scripts/verify-packed-example.sh
@@ -38,15 +38,21 @@ bun remove "$plugin_name"
 bun add "${packed_packages[0]}"
 bun run build
 
+prepare_platform() {
+  local platform_name="$1"
+  rm -rf "$platform_name"
+  bunx cap add "$platform_name"
+}
+
 case "$platform" in
   android)
-    bunx cap add android
+    prepare_platform android
     bunx cap sync android
     cd android
     ./gradlew build test
     ;;
   ios)
-    bunx cap add ios
+    prepare_platform ios
     bunx cap sync ios
     xcodebuild -project ios/App/App.xcodeproj -scheme App -destination generic/platform=iOS CODE_SIGNING_ALLOWED=NO
     ;;

--- a/.github/scripts/verify-packed-example.sh
+++ b/.github/scripts/verify-packed-example.sh
@@ -44,9 +44,17 @@ prepare_platform() {
   bunx cap add "$platform_name"
 }
 
+add_jwplayer_maven_repository() {
+  local gradle_file="android/build.gradle"
+  if ! grep -q "mvn.jwplayer.com" "$gradle_file"; then
+    printf "\nallprojects { repositories { maven { url 'https://mvn.jwplayer.com/content/repositories/releases/' } } }\n" >> "$gradle_file"
+  fi
+}
+
 case "$platform" in
   android)
     prepare_platform android
+    add_jwplayer_maven_repository
     bunx cap sync android
     cd android
     ./gradlew build test

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -17,7 +17,8 @@
 
         <meta-data
             android:name="com.google.android.gms.cast.framework.OPTIONS_PROVIDER_CLASS_NAME"
-            android:value="ee.forgr.capacitor_jw_player.CastOptionsProvider" />
+            android:value="ee.forgr.capacitor_jw_player.CastOptionsProvider"
+            tools:replace="android:value" />
 
         <activity
             android:name=".PlayerActivity"

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application>
 

--- a/example-app/src/js/example.js
+++ b/example-app/src/js/example.js
@@ -1,6 +1,9 @@
 import { JwPlayer } from '@capgo/capacitor-jw-player';
 import { Capacitor } from '@capacitor/core';
-import { licenseKeyIos, licenseKeyAndroid, playerUrl } from './license';
+
+const licenseKeyIos = import.meta.env.VITE_JW_LICENSE_KEY_IOS ?? '';
+const licenseKeyAndroid = import.meta.env.VITE_JW_LICENSE_KEY_ANDROID ?? '';
+const playerUrl = import.meta.env.VITE_JW_PLAYER_URL ?? '';
 
 // For displaying results
 const showResult = (title, data) => {
@@ -368,4 +371,3 @@ async function getState() {
         showResult('Error Getting State', error.message);
     }
 }
-


### PR DESCRIPTION
## What
- Add `tools:replace="android:value"` to the Android Cast provider metadata.
- Add the Android 13+ notification permission required by JW background notifications.
- Fix packed example verification by removing the static ignored license import and restoring generated Android setup for JW dependencies.

## Why
- Apps that install multiple Cast-enabled plugins can fail Android manifest merge because Google Cast allows one `OPTIONS_PROVIDER_CLASS_NAME` metadata value per app.
- CI packed-example checks also needed to pass before the PR can be reviewed.

## How
- Keep the existing JW Cast provider.
- Allow the manifest merger to replace another lower-priority Cast provider value instead of failing on duplicate plugin metadata.
- Keep app-level custom Cast providers as the consuming app's responsibility; higher-priority app manifests still need their own `tools:replace="android:value"` when overriding plugin metadata.
- Read example license/player values from optional Vite env vars instead of an ignored local file.
- Regenerate packed native platforms cleanly and inject the JW Maven repo for Android verification.

## Testing
- Ran `xmllint --noout android/src/main/AndroidManifest.xml`.
- Ran `bun run build`.
- Ran `bun run build` in `example-app`.
- Ran `bash ./.github/scripts/verify-packed-example.sh web`.
- GitHub Actions are passing for web, iOS, and Android.

## Not Tested
- Full local Android Gradle verification could not complete on this machine because the system Java runtime is unavailable; Android verification passed in CI.